### PR TITLE
Fix problem with curlpp on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,15 @@ if (WIN32)
 
     set(liblist fastrtps_static fastcdr_static TinyXML2 ${CMAKE_DL_LIBS} cURLpp IPHLPAPI shlwapi libcurl_a)
 else()
-    set(liblist fastrtps fastcdr -L/usr/lib/x86_64-linux-gnu tinyxml2 curl curlpp)
+    # cURLpp as thirdparty
+    file(GLOB_RECURSE CURLPP_HEADERS thirdparty/curlpp/include/*)
+    file(GLOB_RECURSE CURLPP_SOURCES thirdparty/curlpp/src/*)
+
+    add_library(cURLpp ${CURLPP_HEADERS} ${CURLPP_SOURCES})
+    target_include_directories(cURLpp PUBLIC thirdparty/curlpp/include)
+    set_property(TARGET cURLpp PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    set(liblist fastrtps fastcdr -L/usr/lib/x86_64-linux-gnu tinyxml2 curl cURLpp)
 endif()
 
 target_link_libraries(firos2 ${CMAKE_DL_LIBS} ${liblist})


### PR DESCRIPTION
The version of curlpp that ships with ubuntu 16.04 does not appear to be compatible with Firos2 (linking problems). With this change we use the code in thirdparty/curlpp in Linux like is done on Windows.