### PR TITLE
Fix crash in ISBridgeFastRTPSToNGSIv2::NGSIv2Publisher::write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
         CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     check_cxx_compiler_flag(--std=c++14 SUPPORTS_CXX11)
     if(SUPPORTS_CXX11)
-        add_compile_options(--std=c++14)
+        add_compile_options(--std=c++14 -Wall -Wextra)
     else()
         message(FATAL_ERROR "Compiler doesn't support C++11")
     endif()

--- a/src/NGSIv2/ISBridgeFastRTPSToNGSIv2.cpp
+++ b/src/NGSIv2/ISBridgeFastRTPSToNGSIv2.cpp
@@ -150,7 +150,7 @@ string getPayload(const string json)
     return json.substr(json.find_first_of("@") + 1);
 }
 */
-string ISBridgeFastRTPSToNGSIv2::NGSIv2Publisher::write(SerializedPayload_t* payload)
+void ISBridgeFastRTPSToNGSIv2::NGSIv2Publisher::write(SerializedPayload_t* payload)
 {
     try {
         curlpp::Cleanup cleaner;

--- a/src/NGSIv2/ISBridgeFastRTPSToNGSIv2.h
+++ b/src/NGSIv2/ISBridgeFastRTPSToNGSIv2.h
@@ -77,7 +77,7 @@ private:
         NGSIv2Publisher(const string host, const uint16_t port);
         void setHostPort(const string host, const uint16_t port);
         ~NGSIv2Publisher();
-        string write(SerializedPayload_t *payload);
+        void write(SerializedPayload_t *payload);
     } ngsiv2_publisher;
 
     class SubListener : public SubscriberListener{


### PR DESCRIPTION
This method was missing a return statement, causing a crash when it was called. This commit changes the return type to void. It also increases the warning level in the compiler, so that this type of bug is easier to catch.